### PR TITLE
avoid sp==0 (sign of phi) in faultobliquemerc.m

### DIFF
--- a/BlocksUtilities/faultobliquemerc.m
+++ b/BlocksUtilities/faultobliquemerc.m
@@ -71,6 +71,7 @@ lambdap = rad_to_deg(atan2(num, den));
 % Pole latitude
 phip = atand(-cosd(lambdap - lambda1)./tand(phi1));
 sp = sign(phip);
+sp(sp==0) = 1;
 % Choose northern hemisphere pole
 lambdap(phip < 0) = lambdap(phip < 0) + 180;
 phip(phip < 0) = -phip(phip < 0);


### PR DESCRIPTION
Hi Jack!

There had been a weird issue in Blocks where it would sometimes give all NaNs in more recent version of Matlab. I found it! 

The line in faultobliquemerc (line 72): 
phip = atand(-cosd(lambdap - lambda1)./tand(phi1));
was sometimes returning *exactly* 0 in more recent versions of Matlab (instead of like ~1e-13). So then the next line
sp = sign(phip);
is also zero, which then zeroed out the projections.
I just added: sp(sp==0) = 1;

And everything looks fine now! 

Thanks!